### PR TITLE
Updates deprecated constant to current nameing

### DIFF
--- a/src-ledring/main.cpp
+++ b/src-ledring/main.cpp
@@ -30,8 +30,8 @@ int i = 0; // teller voor opschuiven patroon
 // arduino conventie: setup() wordt bij boot eenmalig uitgevoerd
 void setup() {
   
-  // Initialize the BUILTIN_LED pin as an output
-  pinMode(BUILTIN_LED, OUTPUT);     
+  // Initialize the LED_BUILTIN pin as an output
+  pinMode(LED_BUILTIN, OUTPUT);     
 
   // seriele poort openzetten voor debug data (zorg dat je terminal dezelfde baudrate gebruikt)
   Serial.begin(115200);


### PR DESCRIPTION
This is the definition, clearly indicating we should be using the `LED_BUILTIN` instead of `BUILTIN_LED` naming.

    const int BUILTIN_LED __attribute__((deprecated, weak)) = LED_BUILTIN;